### PR TITLE
bug: correção no reset de filtros ao fechar dialog

### DIFF
--- a/src/app/patient/patient.component.ts
+++ b/src/app/patient/patient.component.ts
@@ -109,7 +109,7 @@ export class PatientComponent implements OnInit {
     });
 
     dialogRef.afterClosed().subscribe(result => {
-      this.ngOnInit();
+      this.applyFilter();
     });
   }
 

--- a/src/app/professional/professional.component.ts
+++ b/src/app/professional/professional.component.ts
@@ -107,7 +107,7 @@ export class ProfessionalComponent implements OnInit {
     });
 
     dialogRef.afterClosed().subscribe(result => {
-      this.ngOnInit();
+      this.applyFilter();
     });
   }
 }

--- a/src/app/user/user.component.ts
+++ b/src/app/user/user.component.ts
@@ -101,7 +101,7 @@ export class UserComponent implements OnInit {
     });
 
     dialogRef.afterClosed().subscribe(result => {
-      this.ngOnInit();
+      this.applyFilter();
     });
   }
 }


### PR DESCRIPTION
# Descrição

Sempre que o usuário selecionava qualquer card de paciente, ou profissional, ou usuário, ao fechar o edit a função de ngOnInit era chamada, fazendo com que todos os filtros se perdessem.
O que eu fiz foi que invés de chamar o NgOnInit, a aplicação passou a chamar o applyFilter. Com isto, a aplicação tem o comportamento esperado e não perde os filtros passados.

## Tipo de alteração

Não marque as opções que não são relevantes.

- [x] Correção de bug (alteração ininterrupta que corrige um problema)
- [ ] Novo recurso (alteração ininterrupta que adiciona funcionalidade)
- [ ] Quebra de alteração (correção ou recurso que faria com que a funcionalidade existente não funcionasse conforme o esperado)
- [ ] Esta alteração requer uma atualização da documentação

# Como isso foi testado?

- Passo 1
Adicione filtros de busca e aplique-os

- Passo 2
Selecione um card para edição

- Passo 3
Feche o card de edição

- Passo 4
Observe que os filtros se mantém

# Lista de controle:

- [x] Meu código segue as diretrizes de estilo deste projeto
- [x] Eu realizei uma auto-revisão do meu próprio código
- [x] Comentei meu código, principalmente em áreas difíceis de entender
- [x] Fiz as alterações correspondentes na documentação
- [x] Minhas alterações não geram novos avisos
